### PR TITLE
datetime field に対する format 指定が適用されない

### DIFF
--- a/lib/dummy_log_generator/generator.rb
+++ b/lib/dummy_log_generator/generator.rb
@@ -146,7 +146,7 @@ module DummyLogGenerator
 
     def datetime(format: "%Y-%m-%d %H:%M:%S.%3N", random: false, value: nil)
       if value
-        Proc.new { value.sprintf(format) }
+        Proc.new { value.strftime(format) }
       elsif random
         Proc.new {
           y = rand(1970..2037);
@@ -156,10 +156,10 @@ module DummyLogGenerator
           min = rand(0..59);
           s = rand(0..59);
           usec = rand(0..999999);
-          Time.local(y, m, d, h, min, s, usec)
+          Time.local(y, m, d, h, min, s, usec).strftime(format)
         }
       else
-        Proc.new { Time.now }
+        Proc.new { Time.now.strftime(format) }
       end
     end
 


### PR DESCRIPTION
```
$ cat sample.conf
configure 'sample' do
  field :time, type: :datetime, format: "[%Y-%m-%d %H:%M:%S]", random: false
end
```

このような config ファイルを引数に取って実行すると

```
$ dummy_log_generator -c sample.conf
time:2014-01-19 02:02:37 +0900
...
```

というように `format` が適用されていない問題に対する Pull Request です。

補足: 以下の環境で確認しています。

```
$ ruby --version
ruby 2.0.0p353 (2013-11-22 revision 43784) [x86_64-darwin13.0.0]
```
