### PR TITLE
add `label_separator` option

### DIFF
--- a/lib/dummer/generator.rb
+++ b/lib/dummer/generator.rb
@@ -3,7 +3,7 @@ module Dummer
     def initialize(setting)
       @message_proc =
         if fields = setting.fields
-          Field.message_proc(fields, setting.labeled, setting.delimiter, setting.label_separator)
+          Field.message_proc(fields, setting.labeled, setting.delimiter, setting.label_delimiter)
         elsif input = setting.input
           Input.message_proc(input)
         else
@@ -74,8 +74,8 @@ module Dummer
     end
 
     class Field
-      def self.message_proc(fields, labeled, delimiter, label_separator)
-        format_proc = format_proc(labeled, delimiter, label_separator)
+      def self.message_proc(fields, labeled, delimiter, label_delimiter)
+        format_proc = format_proc(labeled, delimiter, label_delimiter)
         record_proc = record_proc(fields)
 
         Proc.new {
@@ -102,10 +102,9 @@ module Dummer
         field_procs({"tag" => tag_opts})["tag"]
       end
 
-      def self.format_proc(labeled, delimiter, label_separator)
+      def self.format_proc(labeled, delimiter, label_delimiter)
         if labeled
-          # Proc.new {|fields| "#{fields.map {|key, val| "#{key}:#{val}" }.join(delimiter)}\n" }
-          Proc.new {|fields| "#{fields.map {|key, val| "#{key}" + label_separator + "#{val}" }.join(delimiter)}\n" }
+          Proc.new {|fields| "#{fields.map {|key, val| "#{key}#{label_delimiter}#{val}" }.join(delimiter)}\n" }
         else
           Proc.new {|fields| "#{fields.values.join(delimiter)}\n" }
         end

--- a/lib/dummer/setting.rb
+++ b/lib/dummer/setting.rb
@@ -1,6 +1,6 @@
 module Dummer
   class Setting
-    attr_accessor :rate, :output, :labeled, :label_separator, :delimiter, :fields, :workers, :message, :input
+    attr_accessor :rate, :output, :labeled, :label_delimiter, :delimiter, :fields, :workers, :message, :input
     attr_accessor :host, :port, :tag
 
     def initialize
@@ -9,7 +9,7 @@ module Dummer
       @host = nil
       @port = 24224
       @labeled = true
-      @label_separator = ":"
+      @label_delimiter = ":"
       @delimiter = "\t"
       @tag = {type: :string, value: "dummer"}
       @fields = nil


### PR DESCRIPTION
Added `label_separator` option for purpose to change a separator of label. As a default, `:` is used for a label separator.
## example configuration

```
configure 'sample' do
  output STDOUT
  rate 500
  delimiter "\t"
  labeled true
  label_separator "-"
  field :id, type: :integer, countup: true, format: "%04d"
  field :time, type: :datetime, format: "[%Y-%m-%d %H:%M:%S]", random: false
  field :level, type: :string, any: %w[DEBUG INFO WARN ERROR]
  field :method, type: :string, any: %w[GET POST PUT]
  field :uri, type: :string, any: %w[/api/v1/people /api/v1/textdata /api/v1/messages]
  field :reqtime, type: :float, range: 0.1..5.0
  field :foobar, type: :string, length: 8
end
```
## output

`$ ./bin/dummer -c example/sample-labeled.conf`

```
id-0234 time-[2014-04-11 16:17:59]      level-ERROR     method-PUT      uri-/api/v1/people      reqtime-2.6887441423503167      foobar-qFQVvH3k
id-0235 time-[2014-04-11 16:17:59]      level-DEBUG     method-PUT      uri-/api/v1/messages    reqtime-3.411200515930845       foobar-NHS0S2E6
id-0236 time-[2014-04-11 16:17:59]      level-ERROR     method-PUT      uri-/api/v1/people      reqtime-4.3141302024983 foobar-geTu6Em7
id-0237 time-[2014-04-11 16:17:59]      level-INFO      method-POST     uri-/api/v1/messages    reqtime-2.5077623430663483      foobar-4cAUznB5
id-0238 time-[2014-04-11 16:17:59]      level-INFO      method-POST     uri-/api/v1/textdata    reqtime-0.26060192871914767     foobar-f5Xzm0gV
```
