### PR TITLE
Make worker log redirect to STDOUT

### DIFF
--- a/lib/dummer/cli.rb
+++ b/lib/dummer/cli.rb
@@ -40,6 +40,7 @@ module Dummer
       @options[:setting] = dsl.setting
       # options for serverengine
       @options[:workers] ||= dsl.setting.workers
+      @options[:log] = '-'
 
       opts = @options.symbolize_keys.except(:config)
       se = ServerEngine.create(nil, Dummer::Worker, opts)


### PR DESCRIPTION
tiny fix.
Now, worker output doesn't redirect to console's STDOUT if we set `output STDOUT` in config.
It's caused by missing of option for serverengine.
