### PR TITLE
Make countup integer field stores integer instead of formatted string as prev_data

### DIFF
--- a/lib/dummer/generator.rb
+++ b/lib/dummer/generator.rb
@@ -92,9 +92,10 @@ module Dummer
           data = {}
           field_procs.each do |key, proc|
             prev = prev_data[key] || -1
-            data[key] = proc.call(prev)
+            data[key], prev_candidate = proc.call(prev)
+            prev_data[key] = prev_candidate || data[key]
           end
-          prev_data = data
+          data
         }
       end
 
@@ -176,7 +177,7 @@ module Dummer
         elsif range
           Proc.new { sprintf(format, self.range(range)) }
         elsif countup
-          Proc.new {|prev| sprintf(format, prev.to_i + 1) }
+          Proc.new {|prev| [sprintf(format, prev + 1), prev + 1] }
         else
           Proc.new { sprintf(format, rand(0..2,147,483,647)) }
         end


### PR DESCRIPTION
This conf generates

```
# dummy.conf
configure 'sample' do
  output "dummy.log"
  field :time, type: :integer, countup: true, format: "2013-11-25 00:23:52.%09d"
end
```

this logs.

```
time:2013-11-25 00:23:52.000000000
time:2013-11-25 00:23:52.000000001
time:2013-11-25 00:23:52.000000002
time:2013-11-25 00:23:52.000000003
time:2013-11-25 00:23:52.000000004
time:2013-11-25 00:23:52.000000005
time:2013-11-25 00:23:52.000000006
time:2013-11-25 00:23:52.000000007
time:2013-11-25 00:23:52.000000008
time:2013-11-25 00:23:52.000000009
```